### PR TITLE
Change the Source Map generation path

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -11,7 +11,7 @@ import {
     getValidFiles,
 } from './utils/metalsmith';
 import { loadConfig, processCSS } from './utils/postcss';
-import { findSourceMapFile } from './utils/source-map';
+import { findSourceMapFile, getSourceMappingURL } from './utils/source-map';
 
 const debug = createDebug(require('../package.json').name);
 const debugPostcssrc = debug.extend('postcssrc');
@@ -83,7 +83,8 @@ export = (opts: InputOptions = {}): Metalsmith.Plugin => {
                 );
                 if (!result) return;
 
-                addFile(files, newFilename, result.css, filedata);
+                const cssText = result.css;
+                addFile(files, newFilename, cssText, filedata);
                 if (filename !== newFilename) {
                     debug(
                         'done process %o, renamed to %o',
@@ -97,7 +98,10 @@ export = (opts: InputOptions = {}): Metalsmith.Plugin => {
                 }
 
                 if (result.map) {
-                    const sourceMapFilename = newFilename + '.map';
+                    const sourceMappingURL = getSourceMappingURL(cssText);
+                    const sourceMapFilename = sourceMappingURL
+                        ? path.join(path.dirname(newFilename), sourceMappingURL)
+                        : newFilename + '.map';
                     addFile(files, sourceMapFilename, result.map.toString());
                     debug('generate SourceMap: %o', sourceMapFilename);
                 }

--- a/test/fixtures/change-source-map-path/postcss-plugins
+++ b/test/fixtures/change-source-map-path/postcss-plugins
@@ -1,0 +1,1 @@
+../postcssrc/postcss-plugins

--- a/test/fixtures/change-source-map-path/postcss.config.js
+++ b/test/fixtures/change-source-map-path/postcss.config.js
@@ -1,0 +1,26 @@
+const path = require('path');
+
+module.exports = ctx => {
+  const { metalsmith } = ctx;
+  const destRootPath = metalsmith.destination();
+  const destFullFilepath = ctx.options.to;
+  const destFilepath = path.relative(destRootPath, destFullFilepath);
+  const sourceMapFullFilepath = path.join(
+    destRootPath,
+    '.sourcemap.css',
+    path.dirname(destFilepath),
+    path.basename(destFilepath, '.css') + '.map',
+  );
+  const sourceMapFilepath = path.relative(
+    path.dirname(destFullFilepath),
+    sourceMapFullFilepath,
+  );
+
+  return {
+    plugins: [require('./postcss-plugins/doubler')],
+    map: {
+      inline: false,
+      annotation: sourceMapFilepath,
+    },
+  };
+};

--- a/test/fixtures/change-source-map-path/src/a.css
+++ b/test/fixtures/change-source-map-path/src/a.css
@@ -1,0 +1,1 @@
+a { color: black }

--- a/test/fixtures/change-source-map-path/src/path/b.css
+++ b/test/fixtures/change-source-map-path/src/path/b.css
@@ -1,0 +1,1 @@
+b { color: blue }

--- a/test/fixtures/change-source-map-path/src/path/to/c.css
+++ b/test/fixtures/change-source-map-path/src/path/to/c.css
@@ -1,0 +1,1 @@
+c { color: cyan }

--- a/test/sourcemap.ts
+++ b/test/sourcemap.ts
@@ -192,3 +192,23 @@ for (const options of [{ map: false }, { map: undefined }, {}]) {
         );
     });
 }
+
+test('should change SourceMap file location', async t => {
+    const metalsmith = Metalsmith(fixtures('change-source-map-path'))
+        .source('src')
+        .use(postcss());
+    const files = await processAsync(metalsmith);
+
+    t.truthy(
+        files['.sourcemap.css/a.map'],
+        'should generate SourceMap file in customized location',
+    );
+    t.truthy(
+        files['.sourcemap.css/path/b.map'],
+        'should generate SourceMap file in customized location',
+    );
+    t.truthy(
+        files['.sourcemap.css/path/to/c.map'],
+        'should generate SourceMap file in customized location',
+    );
+});


### PR DESCRIPTION
[Option "map.annotation"](https://github.com/postcss/postcss/blob/7.0.18/docs/source-maps.md#options) that can be set from [postcssrc](https://github.com/michael-ciniawsky/postcss-load-config/tree/v2.1.0) can change the location of the SourceMap file.
Fix code and add this option support.