### PR TITLE
Fix broken SourceMap location

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -3856,16 +3856,23 @@
       "dev": true,
       "requires": {
         "is-path-inside": "^2.1.0"
+      },
+      "dependencies": {
+        "is-path-inside": {
+          "version": "2.1.0",
+          "resolved": "https://registry.npmjs.org/is-path-inside/-/is-path-inside-2.1.0.tgz",
+          "integrity": "sha512-wiyhTzfDWsvwAW53OBWF5zuvaOGlZ6PwYxAbPVDhpm+gM09xKQGjBq/8uYN12aDvMxnAnq3dxTyoSoRNmg5YFg==",
+          "dev": true,
+          "requires": {
+            "path-is-inside": "^1.0.2"
+          }
+        }
       }
     },
     "is-path-inside": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/is-path-inside/-/is-path-inside-2.1.0.tgz",
-      "integrity": "sha512-wiyhTzfDWsvwAW53OBWF5zuvaOGlZ6PwYxAbPVDhpm+gM09xKQGjBq/8uYN12aDvMxnAnq3dxTyoSoRNmg5YFg==",
-      "dev": true,
-      "requires": {
-        "path-is-inside": "^1.0.2"
-      }
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/is-path-inside/-/is-path-inside-3.0.2.tgz",
+      "integrity": "sha512-/2UGPSgmtqwo1ktx8NDHjuPwZWmHhO+gj0f93EkhLB5RgW9RZevWYYlIkS6zePc6U2WpOdQYIwHe9YC4DWEBVg=="
     },
     "is-plain-obj": {
       "version": "1.1.0",

--- a/package.json
+++ b/package.json
@@ -87,6 +87,7 @@
     "@types/metalsmith": "2.3.0",
     "debug": "4.1.1",
     "deep-freeze-strict": "1.1.1",
+    "is-path-inside": "3.0.2",
     "multimatch": "4.0.0",
     "postcss": "7.0.18",
     "postcss-load-config": "2.1.0",

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,9 +1,10 @@
 import createDebug from 'debug';
+import isPathInside from 'is-path-inside';
 import Metalsmith from 'metalsmith';
 import path from 'path';
 
 import { InputOptions, normalizeOptions, OptionsInterface } from './options';
-import { hasProp } from './utils';
+import { hasProp, replaceStrByIndex } from './utils';
 import {
     addFile,
     createPlugin,
@@ -13,7 +14,7 @@ import {
     MetalsmithStrictFiles,
 } from './utils/metalsmith';
 import { loadConfig, processCSS, ProcessOptions } from './utils/postcss';
-import { findSourceMapFile, getSourceMappingURL } from './utils/source-map';
+import { findSourceMapFile, getSourceMappingURLData } from './utils/source-map';
 
 const debug = createDebug(require('../package.json').name);
 const debugPostcssrc = debug.extend('postcssrc');
@@ -65,6 +66,63 @@ function updatePostcssOption(
     return postcssOptions;
 }
 
+function addSourceMap({
+    files,
+    metalsmithSrcFullpath,
+    metalsmithDestFullpath,
+    destFileFullpath,
+    cssText,
+    sourceMapText,
+}: {
+    files: MetalsmithStrictFiles;
+    metalsmithSrcFullpath: string;
+    metalsmithDestFullpath: string;
+    destFileFullpath: string;
+    cssText: string;
+    sourceMapText: string;
+}): { cssText: string } | null {
+    const sourceMappingURLData = getSourceMappingURLData(cssText);
+    const sourceMapFullpath =
+        sourceMappingURLData && sourceMappingURLData.url
+            ? path.resolve(
+                  path.dirname(destFileFullpath),
+                  sourceMappingURLData.url,
+              )
+            : `${destFileFullpath}.map`;
+    const sourceMapFixedFullpath =
+        destFileFullpath === sourceMapFullpath
+            ? `${sourceMapFullpath}.map`
+            : sourceMapFullpath;
+    const sourceMapFilename = path.relative(
+        isPathInside(sourceMapFixedFullpath, metalsmithSrcFullpath)
+            ? metalsmithSrcFullpath
+            : metalsmithDestFullpath,
+        sourceMapFixedFullpath,
+    );
+
+    addFile(files, sourceMapFilename, sourceMapText);
+    debug('generate SourceMap: %o', sourceMapFilename);
+
+    if (sourceMappingURLData) {
+        const fixedSourceMappingURL = path.relative(
+            path.dirname(destFileFullpath),
+            path.resolve(metalsmithDestFullpath, sourceMapFilename),
+        );
+        if (sourceMappingURLData.url !== fixedSourceMappingURL) {
+            return {
+                cssText: replaceStrByIndex(
+                    cssText,
+                    fixedSourceMappingURL,
+                    sourceMappingURLData.startPos,
+                    sourceMappingURLData.endPos,
+                ),
+            };
+        }
+    }
+
+    return null;
+}
+
 async function processFile({
     files,
     metalsmith,
@@ -78,20 +136,23 @@ async function processFile({
     filename: string;
     filedata: FileInterface;
 }): Promise<void> {
+    const metalsmithSrcFullpath = metalsmith.path(metalsmith.source());
+    const metalsmithDestFullpath = metalsmith.path(metalsmith.destination());
+
     const newFilename = options.renamer(filename);
 
-    const from = metalsmith.path(metalsmith.source(), filename);
-    const to = metalsmith.path(metalsmith.destination(), newFilename);
+    const srcFileFullpath = path.resolve(metalsmithSrcFullpath, filename);
+    const destFileFullpath = path.resolve(metalsmithDestFullpath, newFilename);
     const postcssOptions = updatePostcssOption(options.options, {
-        from,
-        to,
+        from: srcFileFullpath,
+        to: destFileFullpath,
         files,
         filename,
         metalsmith,
     });
     const config = await loadConfig({
         options: postcssOptions,
-        sourceFilepath: from,
+        sourceFilepath: srcFileFullpath,
         metalsmith,
     });
     if (config) {
@@ -127,8 +188,8 @@ async function processFile({
         plugins,
         filedata.contents,
         updatePostcssOption(config ? config.options : postcssOptions, {
-            from,
-            to,
+            from: srcFileFullpath,
+            to: destFileFullpath,
             files,
             filename,
             metalsmith,
@@ -136,7 +197,23 @@ async function processFile({
     );
     if (!result) return;
 
-    const cssText = result.css;
+    let cssText = result.css;
+
+    if (result.map) {
+        const updatedData = addSourceMap({
+            files,
+            metalsmithSrcFullpath,
+            metalsmithDestFullpath,
+            destFileFullpath,
+            cssText,
+            sourceMapText: result.map.toString(),
+        });
+
+        if (updatedData) {
+            cssText = updatedData.cssText;
+        }
+    }
+
     addFile(files, newFilename, cssText, filedata);
     if (filename !== newFilename) {
         debug('done process %o, renamed to %o', filename, newFilename);
@@ -144,15 +221,6 @@ async function processFile({
         debug('file deleted: %o', filename);
     } else {
         debug('done process %o', filename);
-    }
-
-    if (result.map) {
-        const sourceMappingURL = getSourceMappingURL(cssText);
-        const sourceMapFilename = sourceMappingURL
-            ? path.join(path.dirname(newFilename), sourceMappingURL)
-            : newFilename + '.map';
-        addFile(files, sourceMapFilename, result.map.toString());
-        debug('generate SourceMap: %o', sourceMapFilename);
     }
 }
 

--- a/src/utils/index.ts
+++ b/src/utils/index.ts
@@ -9,12 +9,3 @@ export function hasProp<
 >(value: T, prop: U): value is T & Required<Pick<T, Extract<keyof T, U>>> {
     return Object.prototype.hasOwnProperty.call(value, prop);
 }
-
-export function replaceStrByIndex(
-    str: string,
-    newSubstr: string,
-    indexStart: number,
-    indexEnd: number,
-): string {
-    return str.substring(0, indexStart) + newSubstr + str.substring(indexEnd);
-}

--- a/src/utils/index.ts
+++ b/src/utils/index.ts
@@ -9,3 +9,12 @@ export function hasProp<
 >(value: T, prop: U): value is T & Required<Pick<T, Extract<keyof T, U>>> {
     return Object.prototype.hasOwnProperty.call(value, prop);
 }
+
+export function replaceStrByIndex(
+    str: string,
+    newSubstr: string,
+    indexStart: number,
+    indexEnd: number,
+): string {
+    return str.substring(0, indexStart) + newSubstr + str.substring(indexEnd);
+}

--- a/src/utils/source-map.ts
+++ b/src/utils/source-map.ts
@@ -12,24 +12,13 @@ import {
 /**
  * @see https://sourcemaps.info/spec.html#h.lmz475t4mvbx
  */
-export function getSourceMappingURLData(
-    cssText: string,
-): { url: string; startPos: number; endPos: number } | null {
+export function getSourceMappingURL(cssText: string): string | null {
     const pattern = /\/\*\s*# sourceMappingURL=((?:(?!\*\/).)*)\*\//g;
-    let url: { url: string; startPos: number; endPos: number } | null = null;
+    let url: string | null = null;
 
     let match: ReturnType<typeof pattern.exec>;
     while ((match = pattern.exec(cssText))) {
-        const urlStr = match[1].trim();
-        const startPos = cssText.indexOf(urlStr, match.index);
-
-        if (startPos >= 0) {
-            url = {
-                url: urlStr,
-                startPos,
-                endPos: startPos + urlStr.length,
-            };
-        }
+        url = match[1].trim();
     }
 
     return url;
@@ -44,15 +33,18 @@ export function findSourceMapFile(
 
     if (isFile(cssFiledata)) {
         const cssText = cssFiledata.contents.toString();
-        const sourceMappingURL = getSourceMappingURLData(cssText);
+        const sourceMappingURL = getSourceMappingURL(cssText);
 
-        if (sourceMappingURL && !validDataUrl(sourceMappingURL.url)) {
+        if (
+            typeof sourceMappingURL === 'string' &&
+            !validDataUrl(sourceMappingURL)
+        ) {
             const cssFilepath = metalsmith
                 ? metalsmith.path(metalsmith.source(), cssFilename)
                 : cssFilename;
             const sourceMapPath = (path.isAbsolute(cssFilepath)
                 ? path.resolve
-                : path.join)(path.dirname(cssFilepath), sourceMappingURL.url);
+                : path.join)(path.dirname(cssFilepath), sourceMappingURL);
             return findFile(files, sourceMapPath, metalsmith);
         }
     }

--- a/test/fixtures/node_modules/postcss-plugins
+++ b/test/fixtures/node_modules/postcss-plugins
@@ -1,0 +1,1 @@
+../postcssrc/postcss-plugins

--- a/test/fixtures/sourcemap-broken-location/postcss.config.js
+++ b/test/fixtures/sourcemap-broken-location/postcss.config.js
@@ -1,0 +1,13 @@
+module.exports = ctx => {
+  const map = { inline: false };
+
+  if (/^src\.[^.]+$/i.test(ctx.file.basename)) {
+    map.annotation = `${ctx.options.from}.map`;
+  } else if (/^dest\.[^.]+$/i.test(ctx.file.basename)) {
+    map.annotation = `${ctx.options.to}.map`;
+  } else if (/^same\.[^.]+$/i.test(ctx.file.basename)) {
+    map.annotation = ctx.options.to;
+  }
+
+  return { map };
+};

--- a/test/fixtures/sourcemap-broken-location/postcss.config.js
+++ b/test/fixtures/sourcemap-broken-location/postcss.config.js
@@ -9,5 +9,8 @@ module.exports = ctx => {
     map.annotation = ctx.options.to;
   }
 
-  return { map };
+  return {
+    plugins: [require('postcss-plugins/doubler')],
+    map,
+  };
 };

--- a/test/helpers/source-map.ts
+++ b/test/helpers/source-map.ts
@@ -1,7 +1,7 @@
 import validDataUrl from 'valid-data-url';
 
 import { hasProp, isObject } from '../../src/utils';
-import { getSourceMappingURLData } from '../../src/utils/source-map';
+import { getSourceMappingURL } from '../../src/utils/source-map';
 import { isStringList } from './';
 
 export interface SourceMap {
@@ -32,23 +32,21 @@ export function isValidSourceMap(value: unknown): value is SourceMap {
 export function getSourceMappingURLType(
     cssData: string | Buffer,
 ): 'file' | 'inline' | null {
-    const sourceMappingURLData = getSourceMappingURLData(cssData.toString());
-    if (sourceMappingURLData) {
-        return validDataUrl(sourceMappingURLData.url) ? 'inline' : 'file';
+    const sourceMappingURL = getSourceMappingURL(cssData.toString());
+    if (typeof sourceMappingURL === 'string') {
+        return validDataUrl(sourceMappingURL) ? 'inline' : 'file';
     }
     return null;
 }
 
 export function readSourceMapURL(cssData: string | Buffer): string | null {
-    const sourceMappingURLData = getSourceMappingURLData(cssData.toString());
-    return sourceMappingURLData ? sourceMappingURLData.url : null;
+    return getSourceMappingURL(cssData.toString());
 }
 
 export function readInlineSourceMap(cssData: string | Buffer): string | null {
-    const sourceMappingURLData = getSourceMappingURLData(cssData.toString());
+    const sourceMappingURL = getSourceMappingURL(cssData.toString());
 
-    if (sourceMappingURLData) {
-        const sourceMappingURL = sourceMappingURLData.url;
+    if (sourceMappingURL) {
         const uri = 'data:application/json,';
         const baseUri = /^data:application\/json;base64,/;
         const baseCharsetUri = /^data:application\/json;charset=utf-?8;base64,/;

--- a/test/helpers/source-map.ts
+++ b/test/helpers/source-map.ts
@@ -39,6 +39,10 @@ export function getSourceMappingURLType(
     return null;
 }
 
+export function readSourceMapURL(cssData: string | Buffer): string | null {
+    return getSourceMappingURL(cssData.toString());
+}
+
 export function readInlineSourceMap(cssData: string | Buffer): string | null {
     const sourceMappingURL = getSourceMappingURL(cssData.toString());
 

--- a/test/helpers/source-map.ts
+++ b/test/helpers/source-map.ts
@@ -1,7 +1,7 @@
 import validDataUrl from 'valid-data-url';
 
 import { hasProp, isObject } from '../../src/utils';
-import { getSourceMappingURL } from '../../src/utils/source-map';
+import { getSourceMappingURLData } from '../../src/utils/source-map';
 import { isStringList } from './';
 
 export interface SourceMap {
@@ -32,21 +32,23 @@ export function isValidSourceMap(value: unknown): value is SourceMap {
 export function getSourceMappingURLType(
     cssData: string | Buffer,
 ): 'file' | 'inline' | null {
-    const sourceMappingURL = getSourceMappingURL(cssData.toString());
-    if (typeof sourceMappingURL === 'string') {
-        return validDataUrl(sourceMappingURL) ? 'inline' : 'file';
+    const sourceMappingURLData = getSourceMappingURLData(cssData.toString());
+    if (sourceMappingURLData) {
+        return validDataUrl(sourceMappingURLData.url) ? 'inline' : 'file';
     }
     return null;
 }
 
 export function readSourceMapURL(cssData: string | Buffer): string | null {
-    return getSourceMappingURL(cssData.toString());
+    const sourceMappingURLData = getSourceMappingURLData(cssData.toString());
+    return sourceMappingURLData ? sourceMappingURLData.url : null;
 }
 
 export function readInlineSourceMap(cssData: string | Buffer): string | null {
-    const sourceMappingURL = getSourceMappingURL(cssData.toString());
+    const sourceMappingURLData = getSourceMappingURLData(cssData.toString());
 
-    if (sourceMappingURL) {
+    if (sourceMappingURLData) {
+        const sourceMappingURL = sourceMappingURLData.url;
         const uri = 'data:application/json,';
         const baseUri = /^data:application\/json;base64,/;
         const baseCharsetUri = /^data:application\/json;charset=utf-?8;base64,/;

--- a/test/sourcemap.ts
+++ b/test/sourcemap.ts
@@ -5,6 +5,7 @@ import path from 'path';
 
 import postcss from '../src/index';
 import { hasProp } from '../src/utils';
+import { switchTest } from './helpers';
 import { debuggerPlugin, processAsync } from './helpers/metalsmith';
 import { doubler } from './helpers/postcss-plugins';
 import {
@@ -59,16 +60,32 @@ test('should generate multi-level SourceMap file', async t => {
     t.notThrows(() => {
         sourceMap = JSON.parse(files['a.css.map'].contents.toString());
     }, 'should parse SourceMap file');
-
-    if (
-        isValidSourceMap(sourceMap) &&
-        sourceMap.sources.includes('../src/a.sass')
-    ) {
-        t.pass('should include the SASS filename in sources property');
-    } else {
-        t.fail('should include the SASS filename in sources property');
-        t.log(sourceMap);
+    if (!isValidSourceMap(sourceMap)) {
+        t.fail('should valid SourceMap file');
+        return;
     }
+
+    switchTest(
+        sourceMap.sources.includes('../src/a.sass'),
+        'should include the SASS filename in sources property',
+        msg => {
+            t.pass(msg);
+        },
+        msg => {
+            t.fail(msg);
+            t.log(sourceMap);
+        },
+    )(
+        sourceMap.file === 'a.css',
+        '"file" property should indicate the original file location',
+        msg => {
+            t.pass(msg);
+        },
+        msg => {
+            t.fail(msg);
+            t.log(sourceMap);
+        },
+    );
 });
 
 test('should not generate multi-level SourceMap file: Manually override the map.prev option', async t => {
@@ -114,16 +131,32 @@ test('should not generate multi-level SourceMap file: Manually override the map.
     t.notThrows(() => {
         sourceMap = JSON.parse(files['a.css.map'].contents.toString());
     }, 'should parse SourceMap file');
-
-    if (
-        isValidSourceMap(sourceMap) &&
-        !sourceMap.sources.includes('../src/a.sass')
-    ) {
-        t.pass('should not include the SASS filename in sources property');
-    } else {
-        t.fail('should not include the SASS filename in sources property');
-        t.log(sourceMap);
+    if (!isValidSourceMap(sourceMap)) {
+        t.fail('should valid SourceMap file');
+        return;
     }
+
+    switchTest(
+        !sourceMap.sources.includes('../src/a.sass'),
+        'should not include the SASS filename in sources property',
+        msg => {
+            t.pass(msg);
+        },
+        msg => {
+            t.fail(msg);
+            t.log(sourceMap);
+        },
+    )(
+        sourceMap.file === 'a.css',
+        '"file" property should indicate the original file location',
+        msg => {
+            t.pass(msg);
+        },
+        msg => {
+            t.fail(msg);
+            t.log(sourceMap);
+        },
+    );
 });
 
 test('should generate multi-level SourceMap file: previous process generates inline SourceMap', async t => {
@@ -166,16 +199,32 @@ test('should generate multi-level SourceMap file: previous process generates inl
     t.notThrows(() => {
         sourceMap = JSON.parse(files['a.css.map'].contents.toString());
     }, 'should parse SourceMap file');
-
-    if (
-        isValidSourceMap(sourceMap) &&
-        sourceMap.sources.includes('../src/a.sass')
-    ) {
-        t.pass('should include the SASS filename in sources property');
-    } else {
-        t.fail('should include the SASS filename in sources property');
-        t.log(sourceMap);
+    if (!isValidSourceMap(sourceMap)) {
+        t.fail('should valid SourceMap file');
+        return;
     }
+
+    switchTest(
+        sourceMap.sources.includes('../src/a.sass'),
+        'should include the SASS filename in sources property',
+        msg => {
+            t.pass(msg);
+        },
+        msg => {
+            t.fail(msg);
+            t.log(sourceMap);
+        },
+    )(
+        sourceMap.file === 'a.css',
+        '"file" property should indicate the original file location',
+        msg => {
+            t.pass(msg);
+        },
+        msg => {
+            t.fail(msg);
+            t.log(sourceMap);
+        },
+    );
 });
 
 test('should generate multi-level inline SourceMap', async t => {
@@ -209,16 +258,32 @@ test('should generate multi-level inline SourceMap', async t => {
     t.notThrows(() => {
         sourceMap = JSON.parse(inlineSourceMapText);
     }, 'should parse inline SourceMap');
-
-    if (
-        isValidSourceMap(sourceMap) &&
-        sourceMap.sources.includes('../src/a.sass')
-    ) {
-        t.pass('should include the SASS filename in sources property');
-    } else {
-        t.fail('should include the SASS filename in sources property');
-        t.log(sourceMap);
+    if (!isValidSourceMap(sourceMap)) {
+        t.fail('should valid SourceMap file');
+        return;
     }
+
+    switchTest(
+        sourceMap.sources.includes('../src/a.sass'),
+        'should include the SASS filename in sources property',
+        msg => {
+            t.pass(msg);
+        },
+        msg => {
+            t.fail(msg);
+            t.log(sourceMap);
+        },
+    )(
+        sourceMap.file === 'a.css',
+        '"file" property should indicate the original file location',
+        msg => {
+            t.pass(msg);
+        },
+        msg => {
+            t.fail(msg);
+            t.log(sourceMap);
+        },
+    );
 });
 
 for (const options of [{ map: false }, { map: undefined }, {}]) {
@@ -249,7 +314,7 @@ for (const options of [{ map: false }, { map: undefined }, {}]) {
     });
 }
 
-test('should change SourceMap file location', async t => {
+test('should change SourceMap file location: a.css', async t => {
     const metalsmith = Metalsmith(fixtures('change-source-map-path'))
         .source('src')
         .use(postcss());
@@ -259,13 +324,143 @@ test('should change SourceMap file location', async t => {
         files['.sourcemap.css/a.map'],
         'should generate SourceMap file in customized location',
     );
+    t.is(
+        getSourceMappingURLType(files['a.css'].contents),
+        'file',
+        'should not exists inline SourceMap',
+    );
+
+    let sourceMap: unknown = null;
+    t.notThrows(() => {
+        sourceMap = JSON.parse(
+            files['.sourcemap.css/a.map'].contents.toString(),
+        );
+    }, 'should parse SourceMap file');
+    if (!isValidSourceMap(sourceMap)) {
+        t.fail('should valid SourceMap file');
+        return;
+    }
+
+    switchTest(
+        sourceMap.sources.includes('../../src/a.css'),
+        'should include source CSS filepath in sources property',
+        msg => {
+            t.pass(msg);
+        },
+        msg => {
+            t.fail(msg);
+            t.log(sourceMap);
+        },
+    )(
+        sourceMap.file === '../a.css',
+        '"file" property should indicate the original file location',
+        msg => {
+            t.pass(msg);
+        },
+        msg => {
+            t.fail(msg);
+            t.log(sourceMap);
+        },
+    );
+});
+
+test('should change SourceMap file location: path/b.css', async t => {
+    const metalsmith = Metalsmith(fixtures('change-source-map-path'))
+        .source('src')
+        .use(postcss());
+    const files = await processAsync(metalsmith);
+
     t.truthy(
         files['.sourcemap.css/path/b.map'],
         'should generate SourceMap file in customized location',
     );
+    t.is(
+        getSourceMappingURLType(files['path/b.css'].contents),
+        'file',
+        'should not exists inline SourceMap',
+    );
+
+    let sourceMap: unknown = null;
+    t.notThrows(() => {
+        sourceMap = JSON.parse(
+            files['.sourcemap.css/path/b.map'].contents.toString(),
+        );
+    }, 'should parse SourceMap file');
+    if (!isValidSourceMap(sourceMap)) {
+        t.fail('should valid SourceMap file');
+        return;
+    }
+
+    switchTest(
+        sourceMap.sources.includes('../../../src/path/b.css'),
+        'should include source CSS filepath in sources property',
+        msg => {
+            t.pass(msg);
+        },
+        msg => {
+            t.fail(msg);
+            t.log(sourceMap);
+        },
+    )(
+        sourceMap.file === '../../path/b.css',
+        '"file" property should indicate the original file location',
+        msg => {
+            t.pass(msg);
+        },
+        msg => {
+            t.fail(msg);
+            t.log(sourceMap);
+        },
+    );
+});
+
+test('should change SourceMap file location: path/to/c.css', async t => {
+    const metalsmith = Metalsmith(fixtures('change-source-map-path'))
+        .source('src')
+        .use(postcss());
+    const files = await processAsync(metalsmith);
+
     t.truthy(
         files['.sourcemap.css/path/to/c.map'],
         'should generate SourceMap file in customized location',
+    );
+    t.is(
+        getSourceMappingURLType(files['path/to/c.css'].contents),
+        'file',
+        'should not exists inline SourceMap',
+    );
+
+    let sourceMap: unknown = null;
+    t.notThrows(() => {
+        sourceMap = JSON.parse(
+            files['.sourcemap.css/path/to/c.map'].contents.toString(),
+        );
+    }, 'should parse SourceMap file');
+    if (!isValidSourceMap(sourceMap)) {
+        t.fail('should valid SourceMap file');
+        return;
+    }
+
+    switchTest(
+        sourceMap.sources.includes('../../../../src/path/to/c.css'),
+        'should include source CSS filepath in sources property',
+        msg => {
+            t.pass(msg);
+        },
+        msg => {
+            t.fail(msg);
+            t.log(sourceMap);
+        },
+    )(
+        sourceMap.file === '../../../path/to/c.css',
+        '"file" property should indicate the original file location',
+        msg => {
+            t.pass(msg);
+        },
+        msg => {
+            t.fail(msg);
+            t.log(sourceMap);
+        },
     );
 });
 
@@ -291,10 +486,16 @@ test('should fix SourceMap file location: Metalsmith source absolute path', asyn
         return;
     }
 
-    t.is(
-        sourceMap.file,
-        'src.css',
+    switchTest(
+        sourceMap.file === 'src.css',
         '"file" property should indicate the original file location',
+        msg => {
+            t.pass(msg);
+        },
+        msg => {
+            t.fail(msg);
+            t.log(sourceMap);
+        },
     );
 });
 
@@ -320,10 +521,16 @@ test('should fix SourceMap file location: Metalsmith destination absolute path',
         return;
     }
 
-    t.is(
-        sourceMap.file,
-        'dest.css',
+    switchTest(
+        sourceMap.file === 'dest.css',
         '"file" property should indicate the original file location',
+        msg => {
+            t.pass(msg);
+        },
+        msg => {
+            t.fail(msg);
+            t.log(sourceMap);
+        },
     );
 });
 
@@ -349,9 +556,15 @@ test('should fix SourceMap file location: Same filename', async t => {
         return;
     }
 
-    t.is(
-        sourceMap.file,
-        'same.css',
+    switchTest(
+        sourceMap.file === 'same.css',
         '"file" property should indicate the original file location',
+        msg => {
+            t.pass(msg);
+        },
+        msg => {
+            t.fail(msg);
+            t.log(sourceMap);
+        },
     );
 });

--- a/test/sourcemap.ts
+++ b/test/sourcemap.ts
@@ -275,8 +275,6 @@ test('should fix SourceMap file location', async t => {
         .use(postcss());
     const files = await processAsync(metalsmith);
 
-    t.log(files);
-
     t.is(
         readSourceMapURL(files['src.css'].contents),
         'src.css.map',

--- a/test/sourcemap.ts
+++ b/test/sourcemap.ts
@@ -269,7 +269,7 @@ test('should change SourceMap file location', async t => {
     );
 });
 
-test('should fix SourceMap file location', async t => {
+test('should fix SourceMap file location: Metalsmith source absolute path', async t => {
     const metalsmith = Metalsmith(fixtures('sourcemap-broken-location'))
         .source('src')
         .use(postcss());
@@ -282,6 +282,28 @@ test('should fix SourceMap file location', async t => {
     );
     t.truthy(files['src.css.map'], 'should generate SourceMap file');
 
+    let sourceMap: unknown = null;
+    t.notThrows(() => {
+        sourceMap = JSON.parse(files['src.css.map'].contents.toString());
+    }, 'should parse SourceMap file');
+    if (!isValidSourceMap(sourceMap)) {
+        t.fail('should valid SourceMap file');
+        return;
+    }
+
+    t.is(
+        sourceMap.file,
+        'src.css',
+        '"file" property should indicate the original file location',
+    );
+});
+
+test('should fix SourceMap file location: Metalsmith destination absolute path', async t => {
+    const metalsmith = Metalsmith(fixtures('sourcemap-broken-location'))
+        .source('src')
+        .use(postcss());
+    const files = await processAsync(metalsmith);
+
     t.is(
         readSourceMapURL(files['dest.css'].contents),
         'dest.css.map',
@@ -289,10 +311,47 @@ test('should fix SourceMap file location', async t => {
     );
     t.truthy(files['dest.css.map'], 'should generate SourceMap file');
 
+    let sourceMap: unknown = null;
+    t.notThrows(() => {
+        sourceMap = JSON.parse(files['dest.css.map'].contents.toString());
+    }, 'should parse SourceMap file');
+    if (!isValidSourceMap(sourceMap)) {
+        t.fail('should valid SourceMap file');
+        return;
+    }
+
+    t.is(
+        sourceMap.file,
+        'dest.css',
+        '"file" property should indicate the original file location',
+    );
+});
+
+test('should fix SourceMap file location: Same filename', async t => {
+    const metalsmith = Metalsmith(fixtures('sourcemap-broken-location'))
+        .source('src')
+        .use(postcss());
+    const files = await processAsync(metalsmith);
+
     t.is(
         readSourceMapURL(files['same.css'].contents),
         'same.css.map',
         'should add ".map" extention in SourceMap filename',
     );
     t.truthy(files['same.css.map'], 'should generate SourceMap file');
+
+    let sourceMap: unknown = null;
+    t.notThrows(() => {
+        sourceMap = JSON.parse(files['same.css.map'].contents.toString());
+    }, 'should parse SourceMap file');
+    if (!isValidSourceMap(sourceMap)) {
+        t.fail('should valid SourceMap file');
+        return;
+    }
+
+    t.is(
+        sourceMap.file,
+        'same.css',
+        '"file" property should indicate the original file location',
+    );
 });

--- a/test/sourcemap.ts
+++ b/test/sourcemap.ts
@@ -11,6 +11,7 @@ import {
     getSourceMappingURLType,
     isValidSourceMap,
     readInlineSourceMap,
+    readSourceMapURL,
 } from './helpers/source-map';
 
 const fixtures = path.join.bind(path, __dirname, 'fixtures');
@@ -266,4 +267,34 @@ test('should change SourceMap file location', async t => {
         files['.sourcemap.css/path/to/c.map'],
         'should generate SourceMap file in customized location',
     );
+});
+
+test('should fix SourceMap file location', async t => {
+    const metalsmith = Metalsmith(fixtures('sourcemap-broken-location'))
+        .source('src')
+        .use(postcss());
+    const files = await processAsync(metalsmith);
+
+    t.log(files);
+
+    t.is(
+        readSourceMapURL(files['src.css'].contents),
+        'src.css.map',
+        'should remove Metalsmith source absolute path',
+    );
+    t.truthy(files['src.css.map'], 'should generate SourceMap file');
+
+    t.is(
+        readSourceMapURL(files['dest.css'].contents),
+        'dest.css.map',
+        'should remove Metalsmith destination absolute path',
+    );
+    t.truthy(files['dest.css.map'], 'should generate SourceMap file');
+
+    t.is(
+        readSourceMapURL(files['same.css'].contents),
+        'same.css.map',
+        'should add ".map" extention in SourceMap filename',
+    );
+    t.truthy(files['same.css.map'], 'should generate SourceMap file');
 });


### PR DESCRIPTION
The value of [the "map.annotation" option](https://github.com/postcss/postcss/blob/7.0.18/docs/source-maps.md#options) is used for the SourceMap path without validation.
A common mistake is to set an absolute path to this option in postcssrc.

- [x] Add test
- [x] Fix code
